### PR TITLE
Fix Unet cropping for same padding

### DIFF
--- a/funlib/learn/torch/models/unet.py
+++ b/funlib/learn/torch/models/unet.py
@@ -392,8 +392,9 @@ class UNet(torch.nn.Module):
                     mode='nearest' if constant_upsample else 'transposed_conv',
                     in_channels=num_fmaps*fmap_inc_factor**(level + 1),
                     out_channels=num_fmaps*fmap_inc_factor**(level + 1),
-                    crop_factor=crop_factors[level],
-                    next_conv_kernel_sizes=kernel_size_up[level])
+                    crop_factor=crop_factors[level] if padding != 'same' else None,
+                    next_conv_kernel_sizes=self.kernel_size_up[level] if padding != 'same' else None
+                )
                 for level in range(self.num_levels - 1)
             ])
             for _ in range(num_heads)

--- a/funlib/tests/test_unet.py
+++ b/funlib/tests/test_unet.py
@@ -14,7 +14,7 @@ class TestUNet(unittest.TestCase):
         unet = models.UNet(
             in_channels=1,
             num_fmaps=3,
-            fmap_inc_factors=2,
+            fmap_inc_factor=2,
             downsample_factors=[[2, 2, 2], [2, 2, 2]])
 
         x = np.zeros((1, 1, 100, 80, 48), dtype=np.float64)
@@ -27,7 +27,7 @@ class TestUNet(unittest.TestCase):
         unet = models.UNet(
             in_channels=1,
             num_fmaps=3,
-            fmap_inc_factors=2,
+            fmap_inc_factor=2,
             downsample_factors=[[2, 2, 2], [2, 2, 2]],
             num_fmaps_out=5)
 
@@ -45,7 +45,7 @@ class TestUNet(unittest.TestCase):
             unet = models.UNet(
                 in_channels=1,
                 num_fmaps=3,
-                fmap_inc_factors=2,
+                fmap_inc_factor=2,
                 downsample_factors=[[2, 3, 2], [2, 2, 2]],
                 num_fmaps_out=5)
             unet.forward(x).data.numpy()
@@ -58,7 +58,7 @@ class TestUNet(unittest.TestCase):
         unet = models.UNet(
             in_channels=1,
             num_fmaps=3,
-            fmap_inc_factors=2,
+            fmap_inc_factor=2,
             downsample_factors=[[2, 2, 2], [2, 2, 2]],
             num_heads=3)
 

--- a/funlib/tests/test_unet.py
+++ b/funlib/tests/test_unet.py
@@ -71,3 +71,19 @@ class TestUNet(unittest.TestCase):
         assert y[0].data.numpy().shape == (1, 3, 60, 40, 8)
         assert y[1].data.numpy().shape == (1, 3, 60, 40, 8)
         assert y[2].data.numpy().shape == (1, 3, 60, 40, 8)
+
+    def test_same_padding(self):
+
+        unet = models.UNet(
+            in_channels=1,
+            num_fmaps=1,
+            fmap_inc_factor=2,
+            downsample_factors=[[2, 2, 2], [2, 2, 2]],
+            padding='same')
+
+        x = np.zeros((1, 1, 100, 80, 48), dtype=np.float64)
+        x = torch.from_numpy(x).float()
+
+        y = unet.forward(x).data.numpy()
+
+        assert y.shape == x.shape


### PR DESCRIPTION
With `same` padding, the output size of a Unet should be equal to its input size.
The cropping function in `Upsample` that ensures translation equivariance
with the total upsampling factor for nets with `valid` padding breaks this
assumption for certain Unet instances.
However, a Unet instance with `same` padding cannot be translation-equivariant,
therefore the cropping mechanism should not be used for nets with `valid` padding.

This PR also fixes a small typo in the Unet tests and adds a new test for Unets with `same` padding.