### PR TITLE
Bugfix: cast to tuple when using plain upsample

### DIFF
--- a/funlib/learn/torch/models/unet.py
+++ b/funlib/learn/torch/models/unet.py
@@ -100,7 +100,7 @@ class Upsample(torch.nn.Module):
             )
 
         else:
-            self.up = torch.nn.Upsample(scale_factor=scale_factor, mode=mode)
+            self.up = torch.nn.Upsample(scale_factor=tuple(scale_factor), mode=mode)
 
         self.padding = padding
 

--- a/tests/test_unet.py
+++ b/tests/test_unet.py
@@ -29,6 +29,21 @@ def test_creation():
         num_fmaps=3,
         fmap_inc_factor=2,
         downsample_factors=[[2, 2, 2], [2, 2, 2]],
+        constant_upsample=True,
+    )
+
+    x = np.zeros((1, 1, 100, 80, 48), dtype=np.float64)
+    x = torch.from_numpy(x).float()
+
+    y = unet.forward(x).data.numpy()
+
+    assert y.shape == (1, 3, 60, 40, 8)
+
+    unet = models.UNet(
+        in_channels=1,
+        num_fmaps=3,
+        fmap_inc_factor=2,
+        downsample_factors=[[2, 2, 2], [2, 2, 2]],
         num_fmaps_out=5,
     )
 


### PR DESCRIPTION
The docstring technically does say to pass a list of tuples as the downsample factor. But all of our tests and examples use lists of lists... so casting fixes the error that occurs when constant_upsample=True.